### PR TITLE
Fixed error with running test_control.py on Mac.

### DIFF
--- a/control/test_control.py
+++ b/control/test_control.py
@@ -153,6 +153,10 @@ class TestControl(unittest.TestCase):
                           + str(alt) + ",0 " + \
                 "--instance " + str(instance))
 
+        # Wait to make sure the simulated drone is completely set up before
+        # continuing.
+        time.sleep(1.0)
+
         port = 5760 + 10 * instance
         return "tcp:127.0.0.1:" + str(port)
 


### PR DESCRIPTION
(Fixed some code/commit message formatting issues from Ryan's commit)

Previously, the code would send the command to set up the simulated copter,
then immediately try, but fail, to connect to it, because the command did not
have enough time to fully set up the copter. Pymavlink automatically tries to
connect again, which works fine since in the time it takes to retry, the copter
is all set up. However, the code for retrying to connect is broken on Mac for
some reason. This has to do with how pymavlink uses the python socket library.
(See https://github.com/ArduPilot/pymavlink/blob/master/mavutil.py#L941 )

The fix is simply to sleep after sending the command to set up the simulated
copter, so it will be ready upon the first try to connect.