### PR TITLE
Add mission pickling and replace unit test sleep with wait for copter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
 *.swp
 .DS_STORE
+*.pickle
 vision/image_simulator/output/

--- a/control/commander/commander.py
+++ b/control/commander/commander.py
@@ -2,6 +2,7 @@ import os
 abspath = os.path.abspath(__file__)
 dname = os.path.dirname(abspath)
 
+import pickle
 import sys
 sys.dont_write_bytecode = True
 sys.path.insert(0, dname + '/../flight_control')
@@ -43,6 +44,11 @@ class Commander:
 
     def stop(self):
         self.copter.stop()
+        self.save_mission_to_file()
+
+    def save_mission_to_file(self):
+        with open(dname+'/mission.pickle', 'wb') as f:
+            pickle.dump(self.commands, f, pickle.HIGHEST_PROTOCOL)
 
     def add_command(self, command):
         with self.commands_lock:

--- a/control/test_control.py
+++ b/control/test_control.py
@@ -1,8 +1,10 @@
 import os
 # Start off fresh by making sure that our working directory is the same as the
 # directory that this script is in.
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
+dname = os.path.dirname(os.path.realpath(__file__))
+os.chdir(dname)
 
+import pickle
 import sys
 sys.dont_write_bytecode = True
 sys.path.insert(0, '../util')
@@ -59,11 +61,20 @@ class TestControl(unittest.TestCase):
 
         test_commander.start_mission()
 
+        test_commander.stop()
+        pickle_location = dname+'/commander/mission.pickle'
+        if not os.path.isfile(pickle_location):
+            print("Did not find mission pickle!")
+        with open(pickle_location, "rb") as f:
+            mission_commands = pickle.load(f)
+            print("Found pickle")
+
     def test_copter_interface_init(self):
         drone_address = self.spawn_simulated_drone(0.0, 0.0, 0.0, 0)
         copter = copter_interface.CopterInterface(drone_address)
 
-        time.sleep(12.0)
+        while not copter.vehicle.is_armable:
+            time.sleep(1.0)
 
         sensors = copter.sensor_reader.sensors.get()
 


### PR DESCRIPTION
Automatically save mission to a pickle file when copter stops. Added a test for the pickle functionality in test_control. Replaced "time.sleep" with a loop waiting for copter to be armable (@RyGuy101 if you could confirm that works natively on Mac that'd be great)